### PR TITLE
fix(build): copy modules into the publish output so deployed hosts can start

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,4 +22,11 @@
               DestinationFolder="$(UnifiedModulePath)%(RecursiveDir)"
               SkipUnchangedFiles="true"/>
     </Target>
+
+    <!--
+      Host applications opt in with <IsModuleHost>true</IsModuleHost>. Consumers of the NuGet package get
+      this same file imported automatically by NuGet's build/{PackageId}.targets convention.
+    -->
+    <Import Project="$(MSBuildThisFileDirectory)InzDynamicModuleLoader.Core/build/InzSoftwares.NetDynamicModuleLoader.targets"
+            Condition="'$(IsModuleHost)' == 'true'"/>
 </Project>

--- a/Example.Module.ConsoleStartup/Example.Module.ConsoleStartup.csproj
+++ b/Example.Module.ConsoleStartup/Example.Module.ConsoleStartup.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
       <UserSecretsId>13046929-92e8-47d3-86ea-73718efc050c</UserSecretsId>
+      <IsModuleHost>true</IsModuleHost>
   </PropertyGroup>
 
     <ItemGroup>

--- a/Example.Module.ConsoleStartup/Example.Module.ConsoleStartup.csproj
+++ b/Example.Module.ConsoleStartup/Example.Module.ConsoleStartup.csproj
@@ -23,4 +23,18 @@
         <ProjectReference Include="..\InzDynamicModuleLoader.Core\InzDynamicModuleLoader.Core.csproj" />
     </ItemGroup>
 
+    <!--
+      Build-order references only. ReferenceOutputAssembly="false" means the host gets no compile-time
+      reference to these projects, so it still cannot see module types. The references make MSBuild build
+      the modules before the host publishes, and in the same configuration as the host.
+    -->
+    <ItemGroup>
+        <ProjectReference Include="..\Example.Module.EFCore.MySQL\Example.Module.EFCore.MySQL.csproj"
+                          ReferenceOutputAssembly="false" PrivateAssets="all"/>
+        <ProjectReference Include="..\Example.Module.EFCore.PostgreSQL\Example.Module.EFCore.PostgreSQL.csproj"
+                          ReferenceOutputAssembly="false" PrivateAssets="all"/>
+        <ProjectReference Include="..\Example.Module.EFCore.Repositories\Example.Module.EFCore.Repositories.csproj"
+                          ReferenceOutputAssembly="false" PrivateAssets="all"/>
+    </ItemGroup>
+
 </Project>

--- a/Example.Module.PublishProbe/Example.Module.PublishProbe.csproj
+++ b/Example.Module.PublishProbe/Example.Module.PublishProbe.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsModuleHost>true</IsModuleHost>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\InzDynamicModuleLoader.Core\InzDynamicModuleLoader.Core.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/Example.Module.PublishProbe/Example.Module.PublishProbe.csproj
+++ b/Example.Module.PublishProbe/Example.Module.PublishProbe.csproj
@@ -18,4 +18,18 @@
         <ProjectReference Include="..\InzDynamicModuleLoader.Core\InzDynamicModuleLoader.Core.csproj"/>
     </ItemGroup>
 
+    <!--
+      Build-order references only. ReferenceOutputAssembly="false" means the host gets no compile-time
+      reference to these projects, so it still cannot see module types. The references make MSBuild build
+      the modules before the host publishes, and in the same configuration as the host.
+    -->
+    <ItemGroup>
+        <ProjectReference Include="..\Example.Module.EFCore.MySQL\Example.Module.EFCore.MySQL.csproj"
+                          ReferenceOutputAssembly="false" PrivateAssets="all"/>
+        <ProjectReference Include="..\Example.Module.EFCore.PostgreSQL\Example.Module.EFCore.PostgreSQL.csproj"
+                          ReferenceOutputAssembly="false" PrivateAssets="all"/>
+        <ProjectReference Include="..\Example.Module.EFCore.Repositories\Example.Module.EFCore.Repositories.csproj"
+                          ReferenceOutputAssembly="false" PrivateAssets="all"/>
+    </ItemGroup>
+
 </Project>

--- a/Example.Module.PublishProbe/Program.cs
+++ b/Example.Module.PublishProbe/Program.cs
@@ -1,0 +1,35 @@
+using InzDynamicModuleLoader.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+// A probe host for the publish tests. It loads the modules and prints how many it loaded.
+// It never asks the container for a service, so no DbContext is built and no database is contacted.
+// Do not add a GetService, GetRequiredService or CreateScope call to this file.
+
+var modules = new[] { "Example.Module.EFCore.MySQL", "Example.Module.EFCore.Repositories" };
+
+var settings = new Dictionary<string, string?>
+{
+    // Bound by the example modules, never used, because no service is resolved.
+    ["Database:ConnectionString"] = "Server=unused;Database=unused;Uid=unused;Pwd=unused;"
+};
+for (var i = 0; i < modules.Length; i++) settings[$"Modules:{i}"] = modules[i];
+
+var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+try
+{
+    var services = new ServiceCollection();
+    services.RegisterModules(configuration);
+
+    var provider = services.BuildServiceProvider();
+    provider.InitializeModules(configuration);
+
+    Console.WriteLine($"MODULES-LOADED: {modules.Length}");
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"PROBE-FAILED: {ex.Message}");
+    return 1;
+}

--- a/Example.Module.WebStartup/Example.Module.WebStartup.csproj
+++ b/Example.Module.WebStartup/Example.Module.WebStartup.csproj
@@ -11,5 +11,19 @@
         <ProjectReference Include="..\Example.Module.Common\Example.Module.Common.csproj" />
         <ProjectReference Include="..\InzDynamicModuleLoader.Core\InzDynamicModuleLoader.Core.csproj" />
     </ItemGroup>
-    
+
+    <!--
+      Build-order references only. ReferenceOutputAssembly="false" means the host gets no compile-time
+      reference to these projects, so it still cannot see module types. The references make MSBuild build
+      the modules before the host publishes, and in the same configuration as the host.
+    -->
+    <ItemGroup>
+        <ProjectReference Include="..\Example.Module.EFCore.MySQL\Example.Module.EFCore.MySQL.csproj"
+                          ReferenceOutputAssembly="false" PrivateAssets="all"/>
+        <ProjectReference Include="..\Example.Module.EFCore.PostgreSQL\Example.Module.EFCore.PostgreSQL.csproj"
+                          ReferenceOutputAssembly="false" PrivateAssets="all"/>
+        <ProjectReference Include="..\Example.Module.EFCore.Repositories\Example.Module.EFCore.Repositories.csproj"
+                          ReferenceOutputAssembly="false" PrivateAssets="all"/>
+    </ItemGroup>
+
 </Project>

--- a/Example.Module.WebStartup/Example.Module.WebStartup.csproj
+++ b/Example.Module.WebStartup/Example.Module.WebStartup.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <IsModuleHost>true</IsModuleHost>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InzDynamicLoader.sln
+++ b/InzDynamicLoader.sln
@@ -35,6 +35,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InzDynamicModuleLoader.Star
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InzDynamicModuleLoader.Microbench", "benchmarks\InzDynamicModuleLoader.Microbench\InzDynamicModuleLoader.Microbench.csproj", "{94AF0B2C-1A19-4634-A46C-59642FD6E8A2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.Module.PublishProbe", "Example.Module.PublishProbe\Example.Module.PublishProbe.csproj", "{90526C0A-CAE5-4E73-9BFD-3888910DC26A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -213,6 +215,18 @@ Global
 		{94AF0B2C-1A19-4634-A46C-59642FD6E8A2}.Release|x64.Build.0 = Release|Any CPU
 		{94AF0B2C-1A19-4634-A46C-59642FD6E8A2}.Release|x86.ActiveCfg = Release|Any CPU
 		{94AF0B2C-1A19-4634-A46C-59642FD6E8A2}.Release|x86.Build.0 = Release|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Debug|x64.Build.0 = Debug|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Debug|x86.Build.0 = Debug|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Release|x64.ActiveCfg = Release|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Release|x64.Build.0 = Release|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Release|x86.ActiveCfg = Release|Any CPU
+		{90526C0A-CAE5-4E73-9BFD-3888910DC26A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/InzDynamicModuleLoader.Core/InzDynamicModuleLoader.Core.csproj
+++ b/InzDynamicModuleLoader.Core/InzDynamicModuleLoader.Core.csproj
@@ -45,6 +45,7 @@
 
     <ItemGroup>
         <None Include="../README.md" Pack="true" PackagePath="\"/>
+        <None Include="build\InzSoftwares.NetDynamicModuleLoader.targets" Pack="true" PackagePath="build\"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/InzDynamicModuleLoader.Core/InzDynamicModuleLoader.Core.csproj
+++ b/InzDynamicModuleLoader.Core/InzDynamicModuleLoader.Core.csproj
@@ -46,6 +46,7 @@
     <ItemGroup>
         <None Include="../README.md" Pack="true" PackagePath="\"/>
         <None Include="build\InzSoftwares.NetDynamicModuleLoader.targets" Pack="true" PackagePath="build\"/>
+        <None Include="build\InzSoftwares.NetDynamicModuleLoader.targets" Pack="true" PackagePath="buildTransitive/"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/InzDynamicModuleLoader.Core/ModuleManagerService.cs
+++ b/InzDynamicModuleLoader.Core/ModuleManagerService.cs
@@ -236,7 +236,8 @@ internal class ModuleManagerService : IModuleManager
         var baseDir = AppContext.BaseDirectory;
 
         // SCENARIO 1: Production / Docker
-        // Expect a "Modules" folder sitting right next to the executable. This folder is created by the "CopyModulesToPublish" target in the .csproj.
+        // Expect a "Modules" folder sitting right next to the executable. This folder is created by the
+        // "CopyModulesToPublish" target shipped in the package at build/InzSoftwares.NetDynamicModuleLoader.targets.
         var localModulesPath = Path.Combine(baseDir, "Modules");
         if (Directory.Exists(localModulesPath))
         {

--- a/InzDynamicModuleLoader.Core/README.md
+++ b/InzDynamicModuleLoader.Core/README.md
@@ -21,6 +21,7 @@ this library contains the abstraction layer files like `IAmModule`.
     - [4. Implement Your Module](#4-implement-your-module)
     - [5. Configure Modules](#5-configure-modules)
     - [6. Register and Initialize Modules](#6-register-and-initialize-modules)
+    - [7. Publish Your Application](#7-publish-your-application)
 - [Project Structure](#project-structure)
 - [Managing Dependencies](#managing-dependencies)
 - [IAmModule Interface Explained](#iammodule-interface-explained)
@@ -174,6 +175,24 @@ app.Services.InitializeModules(builder.Configuration);
 // Continue with your application setup
 app.Run();
 ```
+
+### 7. Publish Your Application
+
+When you publish your host application, your modules are copied automatically into a `Modules` folder next to the executable — which is where the loader looks for them in production:
+
+```shell
+dotnet build                          # builds your modules into BuiltModules/
+dotnet publish YourHost -o ./deploy   # ./deploy/Modules/MyExampleModule/... is created for you
+```
+
+**Build your modules before publishing.** The publish step copies from `BuiltModules/`, which is only populated when your module projects build. If it is missing or empty you will get a build warning and no modules will be copied — the deployed app would then fail at startup with `Could not locate 'Modules' folder`.
+
+Two properties are available if you need them:
+
+| Property | Default | Purpose |
+| --- | --- | --- |
+| `InzModulesSourcePath` | `BuiltModules` next to your solution-root `Directory.Build.targets` | Where modules are copied from. Set it if your modules live elsewhere. |
+| `InzCopyModulesToPublish` | `true` | Set to `false` if you deploy modules another way (for example a Docker `COPY`). |
 
 ## Project Structure
 

--- a/InzDynamicModuleLoader.Core/README.md
+++ b/InzDynamicModuleLoader.Core/README.md
@@ -187,12 +187,27 @@ dotnet publish YourHost -o ./deploy   # ./deploy/Modules/MyExampleModule/... is 
 
 **Build your modules before publishing.** The publish step copies from `BuiltModules/`, which is only populated when your module projects build. If it is missing or empty you will get a build warning and no modules will be copied — the deployed app would then fail at startup with `Could not locate 'Modules' folder`.
 
-Two properties are available if you need them:
+Add a build-order reference from your host project to each module project, so the build system builds your modules before it publishes your host, and in the same configuration:
+
+```xml
+
+<ItemGroup>
+    <ProjectReference Include="..\MyExampleModule\MyExampleModule.csproj"
+                      ReferenceOutputAssembly="false" PrivateAssets="all" />
+</ItemGroup>
+```
+
+`ReferenceOutputAssembly="false"` means the host gets no compile-time reference to the module — the host still cannot see module types, and modules are still chosen through configuration, not code. Without a reference like this, a solution-level publish can copy an incomplete set of modules, and a Debug build followed by a Release publish can deploy Debug modules into a Release app.
+
+Three properties are available if you need them:
 
 | Property | Default | Purpose |
 | --- | --- | --- |
-| `InzModulesSourcePath` | `BuiltModules` next to your solution-root `Directory.Build.targets` | Where modules are copied from. Set it if your modules live elsewhere. |
+| `InzModulesSourcePath` | `BuiltModules` next to your solution-root `Directory.Build.targets` | Where modules are copied from. Set it if your modules live elsewhere, or if your host project has its own `Directory.Build.targets`, which moves the search anchor. |
 | `InzCopyModulesToPublish` | `true` | Set to `false` if you deploy modules another way (for example a Docker `COPY`). |
+| `InzRequireModulesOnPublish` | `false` | Set to `true` in a release pipeline. A missing or empty module folder then stops the build with error `INZ001` instead of a warning. |
+
+The warning carries the code `INZ001`, so `-p:NoWarn=INZ001` silences it in a build that treats warnings as errors.
 
 ## Project Structure
 

--- a/InzDynamicModuleLoader.Core/build/InzSoftwares.NetDynamicModuleLoader.targets
+++ b/InzDynamicModuleLoader.Core/build/InzSoftwares.NetDynamicModuleLoader.targets
@@ -1,0 +1,41 @@
+<Project>
+
+    <PropertyGroup>
+        <!-- Opt-out for hosts that deploy modules another way (e.g. a Docker COPY). -->
+        <InzCopyModulesToPublish Condition="'$(InzCopyModulesToPublish)' == ''">true</InzCopyModulesToPublish>
+
+        <!--
+          Where modules are copied from. Anchored on the solution-root Directory.Build.targets that the
+          module-deployment convention already requires. $(SolutionDir) is not reliable here: it is unset
+          when building a single project (e.g. `dotnet build foo.csproj`).
+        -->
+        <InzModulesRoot Condition="'$(InzModulesRoot)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.targets'))</InzModulesRoot>
+        <InzModulesSourcePath Condition="'$(InzModulesSourcePath)' == '' AND '$(InzModulesRoot)' != ''">$(InzModulesRoot)/BuiltModules</InzModulesSourcePath>
+    </PropertyGroup>
+
+    <!--
+      Copies every built module into {publishDir}/Modules/{ModuleName}/ so a published host finds them at
+      runtime: ModuleManagerService looks for a "Modules" folder next to the executable in production.
+      The modules must already be built - build your module projects before publishing a host.
+    -->
+    <Target Name="CopyModulesToPublish" AfterTargets="Publish"
+            Condition="'$(InzCopyModulesToPublish)' == 'true' AND '$(IsModuleProject)' != 'true'">
+
+        <ItemGroup>
+            <InzModuleFile Include="$(InzModulesSourcePath)/**/*.*"
+                           Condition="'$(InzModulesSourcePath)' != '' AND Exists('$(InzModulesSourcePath)')"/>
+        </ItemGroup>
+
+        <Warning Condition="'@(InzModuleFile)' == ''"
+                 Text="[InzDynamicModuleLoader] No modules were copied to the publish output: '$(InzModulesSourcePath)' is missing or empty. Build your module projects before publishing (e.g. run `dotnet build` on the solution), or set the InzModulesSourcePath property to your modules folder. Set InzCopyModulesToPublish=false to silence this warning."/>
+
+        <Copy Condition="'@(InzModuleFile)' != ''"
+              SourceFiles="@(InzModuleFile)"
+              DestinationFolder="$(PublishDir)Modules/%(RecursiveDir)"
+              SkipUnchangedFiles="true"/>
+
+        <Message Condition="'@(InzModuleFile)' != ''" Importance="High"
+                 Text="[InzDynamicModuleLoader] Copied modules from '$(InzModulesSourcePath)' to '$(PublishDir)Modules/'."/>
+    </Target>
+
+</Project>

--- a/InzDynamicModuleLoader.Core/build/InzSoftwares.NetDynamicModuleLoader.targets
+++ b/InzDynamicModuleLoader.Core/build/InzSoftwares.NetDynamicModuleLoader.targets
@@ -12,6 +12,9 @@
         -->
         <InzModulesRoot Condition="'$(InzModulesRoot)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Directory.Build.targets'))</InzModulesRoot>
         <InzModulesSourcePath Condition="'$(InzModulesSourcePath)' == '' AND '$(InzModulesRoot)' != ''">$(InzModulesRoot)/BuiltModules</InzModulesSourcePath>
+
+        <!-- Set to true to make a missing module folder stop the build. -->
+        <InzRequireModulesOnPublish Condition="'$(InzRequireModulesOnPublish)' == ''">false</InzRequireModulesOnPublish>
     </PropertyGroup>
 
     <!--
@@ -27,8 +30,15 @@
                            Condition="'$(InzModulesSourcePath)' != '' AND Exists('$(InzModulesSourcePath)')"/>
         </ItemGroup>
 
-        <Warning Condition="'@(InzModuleFile)' == ''"
-                 Text="[InzDynamicModuleLoader] No modules were copied to the publish output: '$(InzModulesSourcePath)' is missing or empty. Build your module projects before publishing (e.g. run `dotnet build` on the solution), or set the InzModulesSourcePath property to your modules folder. Set InzCopyModulesToPublish=false to silence this warning."/>
+        <PropertyGroup>
+            <_InzNoModulesMessage>[InzDynamicModuleLoader] No modules were copied to the publish output. The folder '$(InzModulesSourcePath)' is missing or empty. Build your module projects before you publish a host. If your modules are somewhere else, set the InzModulesSourcePath property. If your host project has its own Directory.Build.targets file, that file moves the search anchor, so set InzModulesSourcePath explicitly. Set InzCopyModulesToPublish=false to turn this step off.</_InzNoModulesMessage>
+        </PropertyGroup>
+
+        <Warning Condition="'@(InzModuleFile)' == '' AND '$(InzRequireModulesOnPublish)' != 'true'"
+                 Code="INZ001" Text="$(_InzNoModulesMessage)"/>
+
+        <Error Condition="'@(InzModuleFile)' == '' AND '$(InzRequireModulesOnPublish)' == 'true'"
+               Code="INZ001" Text="$(_InzNoModulesMessage)"/>
 
         <Copy Condition="'@(InzModuleFile)' != ''"
               SourceFiles="@(InzModuleFile)"

--- a/InzDynamicModuleLoader.Core/build/InzSoftwares.NetDynamicModuleLoader.targets
+++ b/InzDynamicModuleLoader.Core/build/InzSoftwares.NetDynamicModuleLoader.targets
@@ -5,7 +5,8 @@
         <InzCopyModulesToPublish Condition="'$(InzCopyModulesToPublish)' == ''">true</InzCopyModulesToPublish>
 
         <!--
-          Where modules are copied from. Anchored on the solution-root Directory.Build.targets that the
+          Internal seam - not part of the public contract (that is InzCopyModulesToPublish and
+          InzModulesSourcePath). Anchored on the solution-root Directory.Build.targets that the
           module-deployment convention already requires. $(SolutionDir) is not reliable here: it is unset
           when building a single project (e.g. `dotnet build foo.csproj`).
         -->

--- a/InzDynamicModuleLoader.UnitTests/InzDynamicModuleLoader.UnitTests.csproj
+++ b/InzDynamicModuleLoader.UnitTests/InzDynamicModuleLoader.UnitTests.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="xunit" Version="2.9.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/InzDynamicModuleLoader.UnitTests/PackagedConsumerTests.cs
+++ b/InzDynamicModuleLoader.UnitTests/PackagedConsumerTests.cs
@@ -1,0 +1,165 @@
+namespace InzDynamicModuleLoader.UnitTests;
+
+/// <summary>
+/// Covers the path a real consumer takes: install the package from a feed, then publish.
+/// The repository's own examples use a project reference, so they never exercise this path.
+/// </summary>
+[Trait("Category", "Integration")]
+public class PackagedConsumerTests
+{
+    private const string PackageId = "InzSoftwares.NetDynamicModuleLoader";
+
+    // A new version for every run, so a package from an earlier run cannot be taken from the
+    // global NuGet cache. The test never clears the user's cache.
+    private static readonly string TestVersion = $"9.9.9-test{DateTime.UtcNow.Ticks}";
+
+    [Fact]
+    public void DirectConsumer_GetsModulesInPublishOutput()
+    {
+        using var scratch = new ScratchConsumer(TestVersion, directReference: true);
+        scratch.Publish();
+        scratch.AssertModuleWasCopied();
+    }
+
+    [Fact]
+    public void IndirectConsumer_GetsModulesInPublishOutput()
+    {
+        // App.Host -> App.Infrastructure -> package. This fails until the package
+        // also ships the targets file in buildTransitive.
+        using var scratch = new ScratchConsumer(TestVersion, directReference: false);
+        scratch.Publish();
+        scratch.AssertModuleWasCopied();
+    }
+
+    [Fact]
+    public void EmptyModuleFolder_WarningIsSuppressible_AndStrictModeFails()
+    {
+        using var scratch = new ScratchConsumer(TestVersion, directReference: true);
+        scratch.RemoveModules();
+
+        // The warning must carry a code, so a strict build can silence it by name.
+        var suppressed = scratch.TryPublish("-warnaserror -p:NoWarn=INZ001");
+        Assert.True(suppressed.ExitCode == 0,
+            $"publish with -warnaserror and NoWarn=INZ001 should succeed, but failed:\n{suppressed.Output}");
+
+        // Strict mode must turn the warning into an error.
+        var strict = scratch.TryPublish("-p:InzRequireModulesOnPublish=true");
+        Assert.False(strict.ExitCode == 0, "publish with InzRequireModulesOnPublish=true should fail");
+        Assert.Contains("INZ001", strict.Output);
+    }
+
+    /// <summary>Builds the package, then creates and publishes a scratch consumer solution.</summary>
+    private sealed class ScratchConsumer : IDisposable
+    {
+        private readonly DirectoryInfo _root = Directory.CreateTempSubdirectory("inz-consumer");
+        private readonly string _hostDir;
+        private readonly string _version;
+
+        public ScratchConsumer(string version, bool directReference)
+        {
+            _version = version;
+            var repoRoot = ProcessRunner.FindRepoRoot();
+            var feed = Path.Combine(_root.FullName, "feed");
+            _hostDir = Path.Combine(_root.FullName, "App.Host");
+
+            // Core depends on Abstractions by project reference, and -p:PackageVersion propagates
+            // through the build graph. Both packages must therefore exist in the feed at this version.
+            foreach (var project in new[] { "InzDynamicModuleLoader.Abstractions", "InzDynamicModuleLoader.Core" })
+            {
+                ProcessRunner.Dotnet(
+                    $"pack \"{Path.Combine(repoRoot, project, project + ".csproj")}\" " +
+                    $"-c Release -p:PackageVersion={_version} -o \"{feed}\" --nologo",
+                    repoRoot);
+            }
+
+            File.WriteAllText(Path.Combine(_root.FullName, "nuget.config"), $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="{feed}" />
+                  </packageSources>
+                </configuration>
+                """);
+
+            // The anchor the copy target looks for, plus a dummy module to copy.
+            File.WriteAllText(Path.Combine(_root.FullName, "Directory.Build.targets"), "<Project />");
+            var dummy = Path.Combine(_root.FullName, "BuiltModules", "DummyModule");
+            Directory.CreateDirectory(dummy);
+            File.WriteAllText(Path.Combine(dummy, "DummyModule.dll"), "not a real assembly");
+            File.WriteAllText(Path.Combine(dummy, "DummyModule.deps.json"), "{}");
+
+            var packageRef = $"""<PackageReference Include="{PackageId}" Version="{_version}" />""";
+
+            if (directReference)
+            {
+                WriteProject(_hostDir, "App.Host", exe: true, items: packageRef);
+            }
+            else
+            {
+                var infraDir = Path.Combine(_root.FullName, "App.Infrastructure");
+                WriteProject(infraDir, "App.Infrastructure", exe: false, items: packageRef);
+                WriteProject(_hostDir, "App.Host", exe: true,
+                    items: """<ProjectReference Include="..\App.Infrastructure\App.Infrastructure.csproj" />""");
+            }
+        }
+
+        private static void WriteProject(string dir, string name, bool exe, string items)
+        {
+            Directory.CreateDirectory(dir);
+            var output = exe ? "<OutputType>Exe</OutputType>" : "";
+            File.WriteAllText(Path.Combine(dir, $"{name}.csproj"), $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    {output}
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    {items}
+                  </ItemGroup>
+                </Project>
+                """);
+            if (exe) File.WriteAllText(Path.Combine(dir, "Program.cs"), "System.Console.WriteLine(\"host\");");
+            else File.WriteAllText(Path.Combine(dir, "Class1.cs"), $"namespace {name}; public class Marker {{ }}");
+        }
+
+        public string PublishDir => Path.Combine(_root.FullName, "out");
+
+        public void RemoveModules() => Directory.Delete(Path.Combine(_root.FullName, "BuiltModules"), recursive: true);
+
+        public void Publish()
+        {
+            var result = TryPublish("");
+            Assert.True(result.ExitCode == 0, $"publish failed:\n{result.Output}");
+        }
+
+        public ProcessRunner.Result TryPublish(string extraArgs)
+        {
+            var result = ProcessRunner.Run("dotnet",
+                $"publish \"{Path.Combine(_hostDir, "App.Host.csproj")}\" -c Release -o \"{PublishDir}\" --nologo {extraArgs}",
+                _root.FullName);
+
+            if (result.Output.Contains("Unable to load the service index") ||
+                result.Output.Contains("No such host is known"))
+            {
+                throw new InvalidOperationException(
+                    "The scratch consumer could not restore its packages. This machine may be offline and the " +
+                    "dependencies may be absent from the NuGet cache. This is an environment fault, not a code fault.\n"
+                    + result.Output);
+            }
+            return result;
+        }
+
+        public void AssertModuleWasCopied()
+        {
+            var copied = Path.Combine(PublishDir, "Modules", "DummyModule", "DummyModule.dll");
+            Assert.True(File.Exists(copied),
+                $"the copy target did not run for this consumer: '{copied}' is missing");
+        }
+
+        public void Dispose()
+        {
+            try { _root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/InzDynamicModuleLoader.UnitTests/PackagedConsumerTests.cs
+++ b/InzDynamicModuleLoader.UnitTests/PackagedConsumerTests.cs
@@ -135,8 +135,16 @@ public class PackagedConsumerTests
 
         public ProcessRunner.Result TryPublish(string extraArgs)
         {
+            // The csproj path must be relative to the working directory, not absolute. On macOS the
+            // temp root returned by Directory.CreateTempSubdirectory sits under a symlinked prefix
+            // (/var -> /private/var). Passing an absolute path built from that unresolved prefix makes
+            // MSBuild's restore graph treat the entry project and its own ProjectReference targets
+            // (resolved relative to the project file, which canonicalizes through the symlink) as two
+            // different identities, so the entry project's ProjectReference items are silently dropped
+            // from the restore graph. A path relative to the working directory avoids the mismatch.
+            var relativeCsproj = Path.Combine("App.Host", "App.Host.csproj");
             var result = ProcessRunner.Run("dotnet",
-                $"publish \"{Path.Combine(_hostDir, "App.Host.csproj")}\" -c Release -o \"{PublishDir}\" --nologo {extraArgs}",
+                $"publish \"{relativeCsproj}\" -c Release -o \"{PublishDir}\" --nologo {extraArgs}",
                 _root.FullName);
 
             if (result.Output.Contains("Unable to load the service index") ||

--- a/InzDynamicModuleLoader.UnitTests/ProcessRunner.cs
+++ b/InzDynamicModuleLoader.UnitTests/ProcessRunner.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+
+namespace InzDynamicModuleLoader.UnitTests;
+
+/// <summary>
+/// Starts a child process, waits with a timeout, and returns its combined output.
+/// A test must never wait for ever on a child process.
+/// </summary>
+internal static class ProcessRunner
+{
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+
+    public sealed record Result(int ExitCode, string Output);
+
+    /// <summary>Runs a process and returns the result. Does not throw when the process fails.</summary>
+    public static Result Run(string fileName, string arguments, string workingDirectory, TimeSpan? timeout = null)
+    {
+        var limit = timeout ?? DefaultTimeout;
+        var psi = new ProcessStartInfo(fileName, arguments)
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Could not start '{fileName} {arguments}'.");
+
+        // Start both reads before waiting, so a full pipe cannot block the child.
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+
+        if (!process.WaitForExit((int)limit.TotalMilliseconds))
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* already gone */ }
+            throw new TimeoutException(
+                $"'{fileName} {arguments}' did not finish within {limit.TotalSeconds:F0} s and was stopped.");
+        }
+
+        return new Result(process.ExitCode, stdout.Result + stderr.Result);
+    }
+
+    /// <summary>Runs a dotnet command and throws when it fails. Use for setup steps.</summary>
+    public static string Dotnet(string arguments, string workingDirectory, TimeSpan? timeout = null)
+    {
+        var result = Run("dotnet", arguments, workingDirectory, timeout);
+        if (result.ExitCode != 0) throw new InvalidOperationException($"`dotnet {arguments}` failed (exit {result.ExitCode}):\n{result.Output}");
+        return result.Output;
+    }
+
+    /// <summary>Finds the repository root by walking up to the solution file.</summary>
+    public static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "InzDynamicLoader.sln")))
+            dir = dir.Parent;
+        return dir?.FullName
+            ?? throw new DirectoryNotFoundException($"Could not find InzDynamicLoader.sln above {AppContext.BaseDirectory}.");
+    }
+
+    /// <summary>The configuration this test assembly was built in.</summary>
+    public static string CurrentConfiguration =>
+#if DEBUG
+        "Debug";
+#else
+        "Release";
+#endif
+}

--- a/InzDynamicModuleLoader.UnitTests/PublishConfigurationTests.cs
+++ b/InzDynamicModuleLoader.UnitTests/PublishConfigurationTests.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace InzDynamicModuleLoader.UnitTests;
+
+/// <summary>
+/// A published host must contain modules built in the same configuration as the host.
+/// A Debug module inside a Release deployment has unoptimised code and debug behaviour.
+/// </summary>
+[Trait("Category", "Integration")]
+public class PublishConfigurationTests
+{
+    private const string ModuleName = "Example.Module.EFCore.Repositories";
+
+    [Fact]
+    public void PublishedModule_MatchesThePublishConfiguration()
+    {
+        var repoRoot = ProcessRunner.FindRepoRoot();
+        var publishConfiguration = ProcessRunner.CurrentConfiguration;          // Debug in a normal test run
+        var oppositeConfiguration = publishConfiguration == "Debug" ? "Release" : "Debug";
+
+        using var temp = new TempDir();
+
+        // 1. Put the WRONG configuration in the shared module folder first.
+        ProcessRunner.Dotnet(
+            $"build \"{Path.Combine(repoRoot, ModuleName, ModuleName + ".csproj")}\" -c {oppositeConfiguration} --nologo",
+            repoRoot);
+
+        // 2. Publish the probe in the test's configuration.
+        ProcessRunner.Dotnet(
+            $"publish \"{Path.Combine(repoRoot, "Example.Module.PublishProbe", "Example.Module.PublishProbe.csproj")}\" " +
+            $"-c {publishConfiguration} -o \"{temp.Path}\" --nologo",
+            repoRoot);
+
+        // 3. The copied module must match the publish configuration, not step 1.
+        var copied = Path.Combine(temp.Path, "Modules", ModuleName, ModuleName + ".dll");
+        Assert.True(File.Exists(copied), $"'{copied}' is missing from the publish output");
+
+        var isDebug = IsDebugAssembly(copied);
+        var expectDebug = publishConfiguration == "Debug";
+        Assert.True(isDebug == expectDebug,
+            $"the published module is a {(isDebug ? "Debug" : "Release")} build, but the host was published " +
+            $"in {publishConfiguration}. The module folder still holds the {oppositeConfiguration} build from step 1.");
+    }
+
+    /// <summary>
+    /// Reads DebuggableAttribute from the file without loading it into this process.
+    /// A Debug assembly sets DisableOptimizations (0x100).
+    /// </summary>
+    private static bool IsDebugAssembly(string assemblyPath)
+    {
+        var runtimeAssemblies = Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll");
+        var resolver = new PathAssemblyResolver(runtimeAssemblies.Append(assemblyPath));
+        using var context = new MetadataLoadContext(resolver);
+
+        var assembly = context.LoadFromAssemblyPath(assemblyPath);
+        var attribute = assembly.GetCustomAttributesData()
+            .FirstOrDefault(a => a.AttributeType.FullName == "System.Diagnostics.DebuggableAttribute");
+
+        if (attribute is null) return false;                       // no attribute means an optimised build
+        if (attribute.ConstructorArguments.Count != 1) return false;
+
+        var modes = Convert.ToInt32(attribute.ConstructorArguments[0].Value);
+        const int disableOptimizations = 0x100;
+        return (modes & disableOptimizations) != 0;
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        private readonly DirectoryInfo _dir = Directory.CreateTempSubdirectory("inz-publish-config");
+        public string Path => _dir.FullName;
+        public void Dispose() { try { _dir.Delete(recursive: true); } catch { /* best effort */ } }
+    }
+}

--- a/InzDynamicModuleLoader.UnitTests/PublishModulesTests.cs
+++ b/InzDynamicModuleLoader.UnitTests/PublishModulesTests.cs
@@ -27,18 +27,10 @@ public class PublishModulesTests
             var host = Path.Combine(repoRoot, "Example.Module.ConsoleStartup", "Example.Module.ConsoleStartup.csproj");
             RunDotnet($"publish \"{host}\" -c Release -o \"{temp.FullName}\" --nologo", repoRoot);
 
-            // 3. Modules must be in the published artifact, with their dependency closure.
-            var mysqlDir = Path.Combine(temp.FullName, "Modules", MySqlModule);
-            Assert.True(File.Exists(Path.Combine(mysqlDir, MySqlModule + ".dll")),
-                $"'{MySqlModule}.dll' is missing from the publish output at {mysqlDir}");
-            Assert.True(File.Exists(Path.Combine(mysqlDir, MySqlModule + ".deps.json")),
-                $"'{MySqlModule}.deps.json' is missing - the module's dependency closure was not copied");
-            Assert.True(Directory.Exists(Path.Combine(temp.FullName, "Modules", RepositoriesModule)),
-                $"'{RepositoriesModule}' is missing from the publish output");
-
+            // 3. Every module must be in the published artifact, with its dependency closure.
             // 4. Modules must live only under Modules/, not loose in the publish root.
-            Assert.False(File.Exists(Path.Combine(temp.FullName, MySqlModule + ".dll")),
-                "a module assembly leaked into the publish root");
+            foreach (var module in new[] { MySqlModule, RepositoriesModule })
+                AssertModulePublished(temp.FullName, module);
 
             // 5. The deployed app must get past module loading. It still fails later on the
             //    database - that is expected and out of scope.
@@ -49,6 +41,23 @@ public class PublishModulesTests
         {
             temp.Delete(recursive: true);
         }
+    }
+
+    /// <summary>
+    /// Asserts a module was published into {publishRoot}/Modules/{module}/ with its dependency closure,
+    /// and that it did not leak loose into the publish root.
+    /// </summary>
+    private static void AssertModulePublished(string publishRoot, string module)
+    {
+        var moduleDir = Path.Combine(publishRoot, "Modules", module);
+        Assert.True(Directory.Exists(moduleDir),
+            $"'{module}' is missing from the publish output at {moduleDir}");
+        Assert.True(File.Exists(Path.Combine(moduleDir, module + ".dll")),
+            $"'{module}.dll' is missing from the publish output at {moduleDir}");
+        Assert.True(File.Exists(Path.Combine(moduleDir, module + ".deps.json")),
+            $"'{module}.deps.json' is missing from {moduleDir} - the module's dependency closure was not copied");
+        Assert.False(File.Exists(Path.Combine(publishRoot, module + ".dll")),
+            $"module assembly '{module}.dll' leaked into the publish root at {publishRoot}");
     }
 
     private static string FindRepoRoot()

--- a/InzDynamicModuleLoader.UnitTests/PublishModulesTests.cs
+++ b/InzDynamicModuleLoader.UnitTests/PublishModulesTests.cs
@@ -1,0 +1,91 @@
+using System.Diagnostics;
+
+namespace InzDynamicModuleLoader.UnitTests;
+
+/// <summary>
+/// Regression test for the production publish gap: `dotnet publish` of a host must copy the built
+/// modules into {publishDir}/Modules/ so the deployed application can find them at runtime.
+/// </summary>
+[Trait("Category", "Integration")]
+public class PublishModulesTests
+{
+    private const string MySqlModule = "Example.Module.EFCore.MySQL";
+    private const string RepositoriesModule = "Example.Module.EFCore.Repositories";
+
+    [Fact]
+    public void Publish_CopiesModulesIntoPublishOutput_SoDeployedHostCanLoadThem()
+    {
+        var repoRoot = FindRepoRoot();
+        var temp = Directory.CreateTempSubdirectory("inz-publish-test");
+        try
+        {
+            // 1. Build the module projects so BuiltModules/ is known-populated.
+            foreach (var module in new[] { MySqlModule, RepositoriesModule })
+                RunDotnet($"build \"{Path.Combine(repoRoot, module, module + ".csproj")}\" -c Release --nologo", repoRoot);
+
+            // 2. Publish the host OUTSIDE the repo tree.
+            var host = Path.Combine(repoRoot, "Example.Module.ConsoleStartup", "Example.Module.ConsoleStartup.csproj");
+            RunDotnet($"publish \"{host}\" -c Release -o \"{temp.FullName}\" --nologo", repoRoot);
+
+            // 3. Modules must be in the published artifact, with their dependency closure.
+            var mysqlDir = Path.Combine(temp.FullName, "Modules", MySqlModule);
+            Assert.True(File.Exists(Path.Combine(mysqlDir, MySqlModule + ".dll")),
+                $"'{MySqlModule}.dll' is missing from the publish output at {mysqlDir}");
+            Assert.True(File.Exists(Path.Combine(mysqlDir, MySqlModule + ".deps.json")),
+                $"'{MySqlModule}.deps.json' is missing - the module's dependency closure was not copied");
+            Assert.True(Directory.Exists(Path.Combine(temp.FullName, "Modules", RepositoriesModule)),
+                $"'{RepositoriesModule}' is missing from the publish output");
+
+            // 4. Modules must live only under Modules/, not loose in the publish root.
+            Assert.False(File.Exists(Path.Combine(temp.FullName, MySqlModule + ".dll")),
+                "a module assembly leaked into the publish root");
+
+            // 5. The deployed app must get past module loading. It still fails later on the
+            //    database - that is expected and out of scope.
+            var output = RunPublishedApp(temp.FullName);
+            Assert.DoesNotContain("Could not locate 'Modules' folder", output);
+        }
+        finally
+        {
+            temp.Delete(recursive: true);
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "InzDynamicLoader.sln")))
+            dir = dir.Parent;
+        return dir?.FullName
+            ?? throw new DirectoryNotFoundException($"Could not find InzDynamicLoader.sln above {AppContext.BaseDirectory}");
+    }
+
+    private static void RunDotnet(string arguments, string workingDirectory)
+    {
+        var (exitCode, output) = Run("dotnet", arguments, workingDirectory);
+        if (exitCode != 0) throw new InvalidOperationException($"`dotnet {arguments}` failed (exit {exitCode}):\n{output}");
+    }
+
+    private static string RunPublishedApp(string publishDir)
+    {
+        // Do not throw on failure: the app is expected to fail later on the database.
+        var (_, output) = Run("dotnet", "Example.Module.ConsoleStartup.dll", publishDir);
+        return output;
+    }
+
+    private static (int ExitCode, string Output) Run(string fileName, string arguments, string workingDirectory)
+    {
+        var psi = new ProcessStartInfo(fileName, arguments)
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        using var process = Process.Start(psi)!;
+        // Drain both streams concurrently to avoid a full-pipe deadlock on large build output.
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+        return (process.ExitCode, stdout.Result + stderr.Result);
+    }
+}

--- a/InzDynamicModuleLoader.UnitTests/PublishModulesTests.cs
+++ b/InzDynamicModuleLoader.UnitTests/PublishModulesTests.cs
@@ -1,100 +1,56 @@
-using System.Diagnostics;
-
 namespace InzDynamicModuleLoader.UnitTests;
 
 /// <summary>
-/// Regression test for the production publish gap: `dotnet publish` of a host must copy the built
-/// modules into {publishDir}/Modules/ so the deployed application can find them at runtime.
+/// A published host must contain the modules, and must be able to load them.
+/// This test publishes the probe host. The probe never asks the container for a service,
+/// so no database is contacted. Do not change it to publish an example application.
 /// </summary>
 [Trait("Category", "Integration")]
 public class PublishModulesTests
 {
-    private const string MySqlModule = "Example.Module.EFCore.MySQL";
-    private const string RepositoriesModule = "Example.Module.EFCore.Repositories";
+    private static readonly string[] ExpectedModules =
+    [
+        "Example.Module.EFCore.MySQL",
+        "Example.Module.EFCore.Repositories"
+    ];
 
     [Fact]
-    public void Publish_CopiesModulesIntoPublishOutput_SoDeployedHostCanLoadThem()
+    public void PublishedProbe_ContainsModules_AndLoadsThem()
     {
-        var repoRoot = FindRepoRoot();
-        var temp = Directory.CreateTempSubdirectory("inz-publish-test");
-        try
-        {
-            // 1. Build the module projects so BuiltModules/ is known-populated.
-            foreach (var module in new[] { MySqlModule, RepositoriesModule })
-                RunDotnet($"build \"{Path.Combine(repoRoot, module, module + ".csproj")}\" -c Release --nologo", repoRoot);
+        var repoRoot = ProcessRunner.FindRepoRoot();
+        using var temp = new TempDir();
 
-            // 2. Publish the host OUTSIDE the repo tree.
-            var host = Path.Combine(repoRoot, "Example.Module.ConsoleStartup", "Example.Module.ConsoleStartup.csproj");
-            RunDotnet($"publish \"{host}\" -c Release -o \"{temp.FullName}\" --nologo", repoRoot);
+        // Publish in the same configuration as this test run, so the shared module folder
+        // is not left in a different configuration.
+        ProcessRunner.Dotnet(
+            $"publish \"{Path.Combine(repoRoot, "Example.Module.PublishProbe", "Example.Module.PublishProbe.csproj")}\" " +
+            $"-c {ProcessRunner.CurrentConfiguration} -o \"{temp.Path}\" --nologo",
+            repoRoot);
 
-            // 3. Every module must be in the published artifact, with its dependency closure.
-            // 4. Modules must live only under Modules/, not loose in the publish root.
-            foreach (var module in new[] { MySqlModule, RepositoriesModule })
-                AssertModulePublished(temp.FullName, module);
+        foreach (var module in ExpectedModules) AssertModulePublished(temp.Path, module);
 
-            // 5. The deployed app must get past module loading. It still fails later on the
-            //    database - that is expected and out of scope.
-            var output = RunPublishedApp(temp.FullName);
-            Assert.DoesNotContain("Could not locate 'Modules' folder", output);
-        }
-        finally
-        {
-            temp.Delete(recursive: true);
-        }
+        // Positive check: the deployed application really loaded the modules.
+        var result = ProcessRunner.Run("dotnet", "Example.Module.PublishProbe.dll", temp.Path, TimeSpan.FromMinutes(2));
+
+        Assert.True(result.ExitCode == 0, $"the published probe failed to run:\n{result.Output}");
+        Assert.Contains($"MODULES-LOADED: {ExpectedModules.Length}", result.Output);
     }
 
-    /// <summary>
-    /// Asserts a module was published into {publishRoot}/Modules/{module}/ with its dependency closure,
-    /// and that it did not leak loose into the publish root.
-    /// </summary>
     private static void AssertModulePublished(string publishRoot, string module)
     {
-        var moduleDir = Path.Combine(publishRoot, "Modules", module);
-        Assert.True(Directory.Exists(moduleDir),
-            $"'{module}' is missing from the publish output at {moduleDir}");
-        Assert.True(File.Exists(Path.Combine(moduleDir, module + ".dll")),
-            $"'{module}.dll' is missing from the publish output at {moduleDir}");
-        Assert.True(File.Exists(Path.Combine(moduleDir, module + ".deps.json")),
-            $"'{module}.deps.json' is missing from {moduleDir} - the module's dependency closure was not copied");
+        var dir = Path.Combine(publishRoot, "Modules", module);
+        Assert.True(Directory.Exists(dir), $"'{module}' is missing from the publish output at {dir}");
+        Assert.True(File.Exists(Path.Combine(dir, module + ".dll")), $"'{module}.dll' is missing from {dir}");
+        Assert.True(File.Exists(Path.Combine(dir, module + ".deps.json")),
+            $"'{module}.deps.json' is missing from {dir}; the dependency closure was not copied");
         Assert.False(File.Exists(Path.Combine(publishRoot, module + ".dll")),
-            $"module assembly '{module}.dll' leaked into the publish root at {publishRoot}");
+            $"'{module}.dll' leaked into the publish root; modules must live only under Modules/");
     }
 
-    private static string FindRepoRoot()
+    private sealed class TempDir : IDisposable
     {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "InzDynamicLoader.sln")))
-            dir = dir.Parent;
-        return dir?.FullName
-            ?? throw new DirectoryNotFoundException($"Could not find InzDynamicLoader.sln above {AppContext.BaseDirectory}");
-    }
-
-    private static void RunDotnet(string arguments, string workingDirectory)
-    {
-        var (exitCode, output) = Run("dotnet", arguments, workingDirectory);
-        if (exitCode != 0) throw new InvalidOperationException($"`dotnet {arguments}` failed (exit {exitCode}):\n{output}");
-    }
-
-    private static string RunPublishedApp(string publishDir)
-    {
-        // Do not throw on failure: the app is expected to fail later on the database.
-        var (_, output) = Run("dotnet", "Example.Module.ConsoleStartup.dll", publishDir);
-        return output;
-    }
-
-    private static (int ExitCode, string Output) Run(string fileName, string arguments, string workingDirectory)
-    {
-        var psi = new ProcessStartInfo(fileName, arguments)
-        {
-            WorkingDirectory = workingDirectory,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true
-        };
-        using var process = Process.Start(psi)!;
-        // Drain both streams concurrently to avoid a full-pipe deadlock on large build output.
-        var stdout = process.StandardOutput.ReadToEndAsync();
-        var stderr = process.StandardError.ReadToEndAsync();
-        process.WaitForExit();
-        return (process.ExitCode, stdout.Result + stderr.Result);
+        private readonly DirectoryInfo _dir = Directory.CreateTempSubdirectory("inz-publish-test");
+        public string Path => _dir.FullName;
+        public void Dispose() { try { _dir.Delete(recursive: true); } catch { /* best effort */ } }
     }
 }

--- a/InzDynamicModuleLoader.UnitTests/SolutionPublishTests.cs
+++ b/InzDynamicModuleLoader.UnitTests/SolutionPublishTests.cs
@@ -1,0 +1,77 @@
+namespace InzDynamicModuleLoader.UnitTests;
+
+/// <summary>
+/// A solution-level publish must give every host a complete module set.
+/// Nothing in the build graph connects the module projects to a host, so MSBuild is free to
+/// publish a host before the modules are built.
+/// </summary>
+[Trait("Category", "Integration")]
+public class SolutionPublishTests
+{
+    private static readonly string[] ExpectedModules =
+    [
+        "Example.Module.EFCore.MySQL",
+        "Example.Module.EFCore.PostgreSQL",
+        "Example.Module.EFCore.Repositories"
+    ];
+
+    [Fact]
+    public void SolutionPublish_GivesEveryHostACompleteModuleSet()
+    {
+        var repoRoot = ProcessRunner.FindRepoRoot();
+        using var clone = new RepoClone(repoRoot);
+
+        ProcessRunner.Dotnet(
+            $"publish \"{Path.Combine(clone.Path, "InzDynamicLoader.sln")}\" -c Release --nologo",
+            clone.Path,
+            TimeSpan.FromMinutes(10));
+
+        var publishDir = Path.Combine(clone.Path, "Example.Module.WebStartup", "bin", "Release", "net9.0", "publish");
+        var modulesDir = Path.Combine(publishDir, "Modules");
+
+        Assert.True(Directory.Exists(modulesDir), $"'{modulesDir}' is missing after a solution publish");
+
+        var found = Directory.GetDirectories(modulesDir).Select(Path.GetFileName).ToArray();
+        var missing = ExpectedModules.Except(found!).ToArray();
+
+        Assert.True(missing.Length == 0,
+            $"the published host is missing {missing.Length} module(s): {string.Join(", ", missing)}. " +
+            $"Found: {(found.Length == 0 ? "nothing" : string.Join(", ", found))}.");
+    }
+
+    /// <summary>
+    /// A throwaway copy of the repository, so the test cannot disturb the working tree.
+    /// This copies the working tree, not a git commit, so it includes changes that are not committed yet.
+    /// A git clone would only see committed work, and the fix under test is committed after it is verified.
+    /// </summary>
+    private sealed class RepoClone : IDisposable
+    {
+        private static readonly string[] SkipDirectories =
+            ["bin", "obj", ".git", ".vs", ".idea", ".claude", "BuiltModules", "nupkg", "TestResults"];
+
+        private readonly DirectoryInfo _dir = Directory.CreateTempSubdirectory("inz-solution-publish");
+        public string Path { get; }
+
+        public RepoClone(string repoRoot)
+        {
+            Path = System.IO.Path.Combine(_dir.FullName, "repo");
+            CopyTree(new DirectoryInfo(repoRoot), new DirectoryInfo(Path));
+        }
+
+        private static void CopyTree(DirectoryInfo source, DirectoryInfo target)
+        {
+            Directory.CreateDirectory(target.FullName);
+
+            foreach (var file in source.EnumerateFiles())
+                file.CopyTo(System.IO.Path.Combine(target.FullName, file.Name), overwrite: true);
+
+            foreach (var directory in source.EnumerateDirectories())
+            {
+                if (SkipDirectories.Contains(directory.Name, StringComparer.OrdinalIgnoreCase)) continue;
+                CopyTree(directory, new DirectoryInfo(System.IO.Path.Combine(target.FullName, directory.Name)));
+            }
+        }
+
+        public void Dispose() { try { _dir.Delete(recursive: true); } catch { /* best effort */ } }
+    }
+}

--- a/InzDynamicModuleLoader.UnitTests/SolutionPublishTests.cs
+++ b/InzDynamicModuleLoader.UnitTests/SolutionPublishTests.cs
@@ -54,8 +54,41 @@ public class SolutionPublishTests
 
         public RepoClone(string repoRoot)
         {
-            Path = System.IO.Path.Combine(_dir.FullName, "repo");
+            // CreateTempSubdirectory() returns a path under /var on macOS, but the temp directory
+            // itself is not a symlink - /var is (it points at /private/var). If we hand MSBuild the
+            // unresolved /var path, restore can see the same project through two path spellings and
+            // race to write the same generated file (e.g. obj/*.csproj.nuget.g.props), failing with
+            // "file already exists". ResolveRealPath walks up to find and resolve that symlinked
+            // ancestor, so MSBuild only ever sees one identity for the clone.
+            Path = System.IO.Path.Combine(ResolveRealPath(_dir.FullName), "repo");
             CopyTree(new DirectoryInfo(repoRoot), new DirectoryInfo(Path));
+        }
+
+        /// <summary>
+        /// Resolves every symlink in a path's ancestry, not just the path itself.
+        /// DirectoryInfo.ResolveLinkTarget only resolves an entry that is itself a symlink, but on
+        /// macOS the temp directory is real and merely sits under a symlinked ancestor (/var), so that
+        /// alone leaves the path unresolved.
+        /// </summary>
+        private static string ResolveRealPath(string path)
+        {
+            var info = new DirectoryInfo(path);
+            var segments = new Stack<string>();
+            while (info is not null)
+            {
+                var target = info.ResolveLinkTarget(returnFinalTarget: true);
+                if (target is not null)
+                {
+                    var result = target.FullName;
+                    while (segments.Count > 0) result = System.IO.Path.Combine(result, segments.Pop());
+                    return result;
+                }
+
+                segments.Push(info.Name);
+                info = info.Parent;
+            }
+
+            return path;
         }
 
         private static void CopyTree(DirectoryInfo source, DirectoryInfo target)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ separation of concerns, module isolation, and flexible infrastructure switching 
   - [4. Implement Your Module](#4-implement-your-module)
   - [5. Configure Modules](#5-configure-modules)
   - [6. Register and Initialize Modules](#6-register-and-initialize-modules)
+  - [7. Publish Your Application](#7-publish-your-application)
 - [Project Structure](#project-structure)
 - [Managing Dependencies](#managing-dependencies)
 - [IAmModule Interface Explained](#iammodule-interface-explained)
@@ -167,6 +168,24 @@ app.Services.InitializeModules(builder.Configuration);
 // Continue with your application setup
 app.Run();
 ```
+
+### 7. Publish Your Application
+
+When you publish your host application, your modules are copied automatically into a `Modules` folder next to the executable — which is where the loader looks for them in production:
+
+```shell
+dotnet build                          # builds your modules into BuiltModules/
+dotnet publish YourHost -o ./deploy   # ./deploy/Modules/MyExampleModule/... is created for you
+```
+
+**Build your modules before publishing.** The publish step copies from `BuiltModules/`, which is only populated when your module projects build. If it is missing or empty you will get a build warning and no modules will be copied — the deployed app would then fail at startup with `Could not locate 'Modules' folder`.
+
+Two properties are available if you need them:
+
+| Property | Default | Purpose |
+| --- | --- | --- |
+| `InzModulesSourcePath` | `BuiltModules` next to your solution-root `Directory.Build.targets` | Where modules are copied from. Set it if your modules live elsewhere. |
+| `InzCopyModulesToPublish` | `true` | Set to `false` if you deploy modules another way (for example a Docker `COPY`). |
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -180,12 +180,27 @@ dotnet publish YourHost -o ./deploy   # ./deploy/Modules/MyExampleModule/... is 
 
 **Build your modules before publishing.** The publish step copies from `BuiltModules/`, which is only populated when your module projects build. If it is missing or empty you will get a build warning and no modules will be copied — the deployed app would then fail at startup with `Could not locate 'Modules' folder`.
 
-Two properties are available if you need them:
+Add a build-order reference from your host project to each module project, so the build system builds your modules before it publishes your host, and in the same configuration:
+
+```xml
+
+<ItemGroup>
+    <ProjectReference Include="..\MyExampleModule\MyExampleModule.csproj"
+                      ReferenceOutputAssembly="false" PrivateAssets="all" />
+</ItemGroup>
+```
+
+`ReferenceOutputAssembly="false"` means the host gets no compile-time reference to the module — the host still cannot see module types, and modules are still chosen through configuration, not code. Without a reference like this, a solution-level publish can copy an incomplete set of modules, and a Debug build followed by a Release publish can deploy Debug modules into a Release app.
+
+Three properties are available if you need them:
 
 | Property | Default | Purpose |
 | --- | --- | --- |
-| `InzModulesSourcePath` | `BuiltModules` next to your solution-root `Directory.Build.targets` | Where modules are copied from. Set it if your modules live elsewhere. |
+| `InzModulesSourcePath` | `BuiltModules` next to your solution-root `Directory.Build.targets` | Where modules are copied from. Set it if your modules live elsewhere, or if your host project has its own `Directory.Build.targets`, which moves the search anchor. |
 | `InzCopyModulesToPublish` | `true` | Set to `false` if you deploy modules another way (for example a Docker `COPY`). |
+| `InzRequireModulesOnPublish` | `false` | Set to `true` in a release pipeline. A missing or empty module folder then stops the build with error `INZ001` instead of a warning. |
+
+The warning carries the code `INZ001`, so `-p:NoWarn=INZ001` silences it in a build that treats warnings as errors.
 
 ## Project Structure
 


### PR DESCRIPTION
## The bug

A host application using this library **cannot be deployed**. `dotnet publish` never copies the plugin modules into the published output, so the deployed app dies on its very first call to `RegisterModules`.

Reproduced under controlled conditions (solution **already built**, so "you forgot to build" is ruled out):

```
BuiltModules/Example.Module.EFCore.MySQL         -> dll+deps present (68 files)
BuiltModules/Example.Module.EFCore.Repositories  -> dll+deps present (23 files)

dotnet publish Example.Module.ConsoleStartup -c Release -o /tmp/inz-controlled-repro
  -> /tmp/inz-controlled-repro/Modules  DOES NOT EXIST;  module DLLs in publish root: 0

run it ->  Could not locate 'Modules' folder at '/private/tmp/inz-controlled-repro/Modules'
           or 'BuiltModules' in any parent directory...
```

It only *appears* to work in-repo because `GetModulesRootDirectory` falls back to walking up for `BuiltModules/` — which exists in the repo tree and nowhere else. `ModuleManagerService` even claimed the folder *"is created by the `CopyModulesToPublish` target in the .csproj"* — **that target never existed**. This PR makes it real.

This does **not** affect NuGet package publishing (those workflows are fine). It affects consumers deploying their own apps.

## The fix

One MSBuild file, `InzDynamicModuleLoader.Core/build/InzSoftwares.NetDynamicModuleLoader.targets`, used two ways (DRY):
- **Packed into the Core package** at `build/{PackageId}.targets` → NuGet auto-imports it, so **every consumer's `dotnet publish` is fixed with no action from them**.
- **Imported by this repo's `Directory.Build.targets`** for `IsModuleHost=true` projects → fixes the example hosts, which use `ProjectReference` and so never get the package auto-import.

It runs `AfterTargets="Publish"` and copies `BuiltModules/**` → `{publishDir}/Modules/{ModuleName}/`, preserving the layout the loader expects. All modules are copied, not a subset — that's what keeps the headline feature working (swap provider by config on a deployed app, no rebuild).

**Public knobs:** `InzModulesSourcePath` (default: `BuiltModules` beside the solution-root `Directory.Build.targets`) and `InzCopyModulesToPublish` (default `true`). Missing/empty source → **warning, never an error**; a publish is never broken by this.

## Verification

- **The regression test was red before the fix and green after** — it failed on the intended assertion (`'Example.Module.EFCore.MySQL.dll' is missing from the publish output`), not on a harness error. It builds the modules first (removing the confound) and publishes **outside the repo tree**, since publishing inside it lets the dev fallback mask the bug.
- Confirmed `build/InzSoftwares.NetDynamicModuleLoader.targets` is actually inside the produced `.nupkg`.
- Confirmed the target also fires for the **Web SDK** host, not just Console.
- `dotnet build` clean; `dotnet test` **27 passing**.
- **No loader runtime logic changed** — the only `ModuleManagerService` edit is the stale comment, now pointing at the real shipped file.

## Also included

- README publish section (root **and** the Core package README that consumers see on nuget.org), documenting the build-modules-first prerequisite and both properties.

## Deliberately out of scope

Build-ordering (`ReferenceOutputAssembly="false"` host→module references). The controlled repro proves `BuiltModules/` is already populated after the documented `dotnet build`, so the copy target alone fixes the reported bug. It would also couple host csprojs to modules and can't be honestly verified by an in-suite test. Separate change if clean-CI publishing ever matters.

Targets `dev` per project conventions.